### PR TITLE
Custom watch attributes

### DIFF
--- a/addon/globalPlugins/objWatcher/settings.py
+++ b/addon/globalPlugins/objWatcher/settings.py
@@ -20,7 +20,7 @@ class ObjWatcherPanel(gui.settingsDialogs.SettingsPanel):
 	# Translators: This is the label for the ObjWatcher settings panel.
 	title = _("ObjWatcher")
 
-	def makeSettings(self, settingsSizer):
+	def makeSettings(self, settingsSizer: wx.BoxSizer):
 		settingsSizerHelper = guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: This is the label of a SpinCtrl in the ObjWatcher settings panel
 		# This option controls the interval of the Watcher timer (in milliseconds)
@@ -35,11 +35,15 @@ class ObjWatcherPanel(gui.settingsDialogs.SettingsPanel):
 		self._appendWatchAttributesList(settingsSizerHelper)
 
 	def _appendWatchAttributesList(self, settingsSizerHelper: guiHelper.BoxSizerHelper) -> None:
+		# Translators: This is the label of a EditableListBox in the ObjWatcher settings panel
+		# This list custom the attributes of the object to be watched
+		watchAttributesLabelText = _("Watch attributes")
 		self.watchAttributesList: wx.adv.EditableListBox = wx.adv.EditableListBox(
 			self,
-			label=_("Watch attributes"),
+			label=watchAttributesLabelText,
 		)
 		self.watchAttributesList.SetStrings(config.conf["objWatcher"]["watchAttributes"].split(","))
+		self.watchAttributesList.SetLabel(watchAttributesLabelText)
 		editBtn: wx.BitmapButton = self.watchAttributesList.GetEditButton()
 		editBtn.SetLabel(editBtn.GetToolTipText())
 		newBtn: wx.BitmapButton = self.watchAttributesList.GetNewButton()
@@ -50,6 +54,12 @@ class ObjWatcherPanel(gui.settingsDialogs.SettingsPanel):
 		upBtn.SetLabel(upBtn.GetToolTipText())
 		downBtn: wx.BitmapButton = self.watchAttributesList.GetDownButton()
 		downBtn.SetLabel(downBtn.GetToolTipText())
+
+		attrLst: wx.ListCtrl = self.watchAttributesList.GetListCtrl()
+		attrLst.MoveBeforeInTabOrder(editBtn.GetParent())
+		attrLst.SetLabel(watchAttributesLabelText)
+		attrLst.EnableCheckBoxes(True)
+		attrLst.Select(0)
 
 		settingsSizerHelper.addItem(self.watchAttributesList)
 

--- a/addon/globalPlugins/objWatcher/settings.py
+++ b/addon/globalPlugins/objWatcher/settings.py
@@ -57,11 +57,23 @@ class ObjWatcherPanel(gui.settingsDialogs.SettingsPanel):
 
 		attrLst: wx.ListCtrl = self.watchAttributesList.GetListCtrl()
 		attrLst.MoveBeforeInTabOrder(editBtn.GetParent())
+		attrLst.Bind(wx.EVT_LIST_BEGIN_LABEL_EDIT, self.onBeginEditingForListCtrl)
 		attrLst.SetLabel(watchAttributesLabelText)
 		attrLst.EnableCheckBoxes(True)
 		attrLst.Select(0)
 
 		settingsSizerHelper.addItem(self.watchAttributesList)
+
+	def onIgnoreDialogCharHookEvent(self, evt: wx.KeyEvent):
+		evt.DoAllowNextEvent()
+
+	def onBeginEditingForListCtrl(self, evt: wx.ListEvent):
+		evtObj: wx.ListCtrl = evt.GetEventObject()
+		editCtrl = evtObj.GetEditControl()
+		if isinstance(editCtrl, wx.TextCtrl):
+			editCtrl.Bind(wx.EVT_CHAR_HOOK, handler=self.onIgnoreDialogCharHookEvent)
+		else:
+			evt.Skip()
 
 	def onSave(self):
 		config.conf["objWatcher"]["interval"] = self.intervalEdit.Value

--- a/addon/globalPlugins/objWatcher/settings.py
+++ b/addon/globalPlugins/objWatcher/settings.py
@@ -9,6 +9,10 @@ import gui
 from gui import guiHelper
 from gui import nvdaControls
 
+import wx
+import wx.adv
+
+
 addonHandler.initTranslation()
 
 
@@ -28,5 +32,27 @@ class ObjWatcherPanel(gui.settingsDialogs.SettingsPanel):
 			initial=int(config.conf["objWatcher"]["interval"])
 		)
 
+		self._appendWatchAttributesList(settingsSizerHelper)
+
+	def _appendWatchAttributesList(self, settingsSizerHelper: guiHelper.BoxSizerHelper) -> None:
+		self.watchAttributesList: wx.adv.EditableListBox = wx.adv.EditableListBox(
+			self,
+			label=_("Watch attributes"),
+		)
+		self.watchAttributesList.SetStrings(config.conf["objWatcher"]["watchAttributes"].split(","))
+		editBtn: wx.BitmapButton = self.watchAttributesList.GetEditButton()
+		editBtn.SetLabel(editBtn.GetToolTipText())
+		newBtn: wx.BitmapButton = self.watchAttributesList.GetNewButton()
+		newBtn.SetLabel(newBtn.GetToolTipText())
+		delBtn: wx.BitmapButton = self.watchAttributesList.GetDelButton()
+		delBtn.SetLabel(delBtn.GetToolTipText())
+		upBtn: wx.BitmapButton = self.watchAttributesList.GetUpButton()
+		upBtn.SetLabel(upBtn.GetToolTipText())
+		downBtn: wx.BitmapButton = self.watchAttributesList.GetDownButton()
+		downBtn.SetLabel(downBtn.GetToolTipText())
+
+		settingsSizerHelper.addItem(self.watchAttributesList)
+
 	def onSave(self):
 		config.conf["objWatcher"]["interval"] = self.intervalEdit.Value
+		config.conf["objWatcher"]["watchAttributes"] = ",".join(self.watchAttributesList.GetStrings())


### PR DESCRIPTION
Closed #6

This PR is currently in draft form and needs to be improved for accessibility to UI/UX.

## Known Issues:

* The EditableListBox is not bound to a static text label.
* No changes to list items are reported when the list is manipulated via the Move Up/Move Down buttons.
* It can be tedious to translate watch attributes.
<!--* Unable to complete the creation of a list item with the Enter key for the same reason as https://github.com/nvaccess/nvda/issues/8482.
    * The code that causes this behavior is the `_enterActivatesOk_ctrlSActivatesApply` method in `gui.settingsDialogs.SettingsDialog` binding to the `wx.EVT_CHAR_HOOK` event.-->
* The checkbox state is not binding to the watch attribute.
* Extra empty list items appear at the end of the list when the checkbox style of ListCtrl is enabled.